### PR TITLE
Use `all-in-one` container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,32 +19,10 @@ services:
       - 8888:8888
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
-  postgres:
-    image: postgres:14.0
-    hostname: 'postgres'
-    container_name: 'postgres'
-    ports:
-      - 5432:5432
-    environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
-      - POSTGRES_DB=meteor
   ferretdb:
-    image: ghcr.io/ferretdb/ferretdb:latest
+    image: ghcr.io/ferretdb/all-in-one:latest
     hostname: 'ferretdb'
     container_name: 'ferretdb'
     restart: 'on-failure'
-    command:
-      [
-        '-listen-addr=:27017',
-        '-postgresql-url=postgres://postgres@postgres:5432/meteor',
-      ]
     ports:
       - 27017:27017
-  setup:
-    image: postgres:14.0
-    hostname: 'setup'
-    container_name: 'setup'
-    restart: 'on-failure'
-    depends_on:
-      - 'postgres'
-    entrypoint: ["sh", "-c", "psql -h postgres -U postgres -d meteor -c 'CREATE SCHEMA IF NOT EXISTS tasks'"]


### PR DESCRIPTION
Thanks for your interest! This PR uses the [all-in-one](https://github.com/FerretDB/FerretDB#quickstart) container which makes testing easier by running FerretDB, PostgreSQL and `mongosh` as a single service.